### PR TITLE
Trim and downcase the email as the username

### DIFF
--- a/lib/coherence/controllers/password_controller.ex
+++ b/lib/coherence/controllers/password_controller.ex
@@ -43,7 +43,11 @@ defmodule Coherence.PasswordController do
   @spec create(conn, params) :: conn
   def create(conn, %{"password" => password_params} = params) do
     user_schema = Config.user_schema
-    email = password_params["email"]
+    email =
+      password_params["email"]
+      |> String.downcase()
+      |> String.trim()
+
     user =
       user_schema
       |> where([u], u.email == ^email)

--- a/lib/coherence/controllers/session_controller.ex
+++ b/lib/coherence/controllers/session_controller.ex
@@ -79,6 +79,8 @@ defmodule Coherence.SessionController do
     login =
       params["session"][login_field_str]
       |> String.downcase()
+      |> String.trim()
+
     new_bindings = [{login_field, login}, remember: rememberable_enabled?()]
     remember = if Config.user_schema.rememberable?(), do: params["remember"], else: false
     user = Config.repo.one(from u in user_schema, where: field(u, ^login_field) == ^login)

--- a/lib/coherence/controllers/unlock_controller.ex
+++ b/lib/coherence/controllers/unlock_controller.ex
@@ -40,7 +40,11 @@ defmodule Coherence.UnlockController do
   @spec create(conn, params) :: conn
   def create(conn, %{"unlock" => unlock_params} = params) do
     user_schema = Config.user_schema()
-    email = unlock_params["email"]
+    email =
+      unlock_params["email"]
+      |> String.downcase()
+      |> String.trim()
+
     password = unlock_params["password"]
 
     user =


### PR DESCRIPTION
trimming is needed cause the space at the beginning and at the end is not important

downcase is needed to be added in the password reset and unlock controller